### PR TITLE
Improve production deploy strategy with tag version

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,18 +1,18 @@
-name: CI/CD Production
+name: CD - Production
 
 env:
-  VSCE_DEPLOY_TOKEN: ${{ secrets.VSCE_DEPLOY_TOKEN }}
+  VSCE_DEPLOY_TOKEN: ${{ secrets.VSCE_DEPLOY_TOKEN }} # set visual studio deploy token globally
 on:
   push:
     tags:
-      - deploy-v*.*.*
+      - prod-v*.*.*
 jobs:
   publish:
-    name: Publish extension, using node ${{ matrix.node_version }} on ${{ matrix.os }}
+    name: Deploy extension to production, with node ${{ matrix.node_version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ["12"]
+        node_version: ['12']
         os: [ubuntu-latest]
 
     steps:
@@ -21,6 +21,18 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node_version }}
+
+      - name: Extract version from tag name
+        uses: olegtarasov/get-tag@v2 # that generate $GIT_TAG_NAME env follows semantic versioning
+        id: tagName
+        with:
+          tagRegex: 'prod-v([0-9]+.[0-9]+.[0-9]+)' # Optional. Returns specified group text as tag name. Full tag string is returned if regex is not defined.
+          tagRegexGroup: 1 # Optional. Default is 1.
+
+      - name: Replace package.json version with tag version
+        run: |
+          sed -i 's/99.99.99/'$GIT_TAG_NAME'/g' package.json|
+          echo "Tag version used:"$GIT_TAG_NAME
 
       - name: npm install and publish
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.20.5
+
+-   FIX - Improved CI/CD for deploy in production, now only need change the version on tagname like prod-v0.20.5 this will build and send the version 0.20.5 to the Extensions.
+
 ## 0.20.4
 
 -   NEW - Tests for apk file picker, including apk install use cases.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "adb-interface-vscode",
   "displayName": "ADB Interface for VSCode",
   "description": "An interface that allows ADB commands inside IDE with no need to have terminal access.",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "publisher": "vinicioslc",
   "repository": "https://github.com/vinicioslc/adb-interface-vscode",
   "engines": {


### PR DESCRIPTION
Improved CI/CD for deploy for production, its only needs the version on tag name like ´prod-v0.20.5´ and this will replace the package.json version, build and send to the vscode extensions.

issue #17