### PR TITLE
:truck: chore(changelog): standarlize changelog.md and remove invalid files from release-it bumper

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -17,14 +17,7 @@
     "beforeStage": "./node_modules/.bin/conventional-changelog -p @favoloso/emoji -i CHANGELOG.md -s"
   },
   "plugins": {
-    "@release-it/bumper": {
-      "out": [
-        "./client/package.json",
-        "./server/package.json",
-        "./docs/package.json",
-        "./generator/package.json"
-      ]
-    }
+    "@release-it/bumper": {}
   },
   "hooks": {
     "after:bump": "npx gitmoji-changelog -y --group-similar-commits && git add CHANGELOG.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,91 +1,321 @@
-# CHANGELOG
+# Changelog
 
-## 0.22.1
+<a name="0.22.1"></a>
+## 0.22.1 (2022-10-30)
 
--   ADD - Bump version
+### Changed
 
-## 0.22.0
+- 🚚 chore(release-action): remove invalid files from release-it config [[54fd1eb](https://github.com/vinicioslc/adb-interface-vscode/commit/54fd1eb531c869210156b821871d4759bf8c3411)]
 
--   FIX - Remove the deprecated `vscode` package due vscode package spliting [vscode changelog](https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest)
+### Fixed
 
-## 0.21.1
+- 💚 ci(versioning): add new release workflow to generate releases and emoji to commits [[b8c8329](https://github.com/vinicioslc/adb-interface-vscode/commit/b8c8329f0e0d61076defcdf1329cf019a9d53db7)]
 
--   FIX - Get version from tag name on release build pipeline.
+### Miscellaneous
 
-## 0.21.0
+-  Merge pull request [#60](https://github.com/vinicioslc/adb-interface-vscode/issues/60) from vinicioslc/docs/improv-readme-docs [[1362ea9](https://github.com/vinicioslc/adb-interface-vscode/commit/1362ea97b0a37c4539e9f4f633f3560cbf3e00c9)]
+- 📝 docs(readme): remove not allowed svg on readme, distribute sections better for vscocde extensions page [[8a6d064](https://github.com/vinicioslc/adb-interface-vscode/commit/8a6d0645fc6b1b8518086bc872c64af98db8ec08)]
+-  Merge pull request [#58](https://github.com/vinicioslc/adb-interface-vscode/issues/58) from vinicioslc/ci/add-emoji-commits-workflow-to-deploy [[55b7ef6](https://github.com/vinicioslc/adb-interface-vscode/commit/55b7ef6bf7bfb037645e3def0fe84053ecf9fc69)]
+-  Merge pull request [#57](https://github.com/vinicioslc/adb-interface-vscode/issues/57) from vinicioslc/ci/auto-merge-workflow [[f7c0db9](https://github.com/vinicioslc/adb-interface-vscode/commit/f7c0db951727b5fd8e2667882f4c9ca0a6ea5ae6)]
+-  ci: add auto merge action to merge PRs when they succeed in tests [[afd4729](https://github.com/vinicioslc/adb-interface-vscode/commit/afd47292567b1baf9057c1bf459e4e19f885af31)]
+-  Merge pull request [#53](https://github.com/vinicioslc/adb-interface-vscode/issues/53) from vinicioslc/fix/typescript-version-refactor [[9aa828a](https://github.com/vinicioslc/adb-interface-vscode/commit/9aa828a61b047a19891f34d1a1e2cbffbbd603d9)]
+-  style: remove unecessary imports [[e62ab5b](https://github.com/vinicioslc/adb-interface-vscode/commit/e62ab5bc60d5f0a9d98099ecb0adb60ef5b49e6c)]
+-  Merge commit &#x27;3f0c94c7b5ec4e28e8e5652d1ddee85737c10f37&#x27; into fix/typescript-version-refactor [[6998ea2](https://github.com/vinicioslc/adb-interface-vscode/commit/6998ea28b51568dbdd1a5cfdac89b38e90d799e4)]
+-  Merge pull request [#52](https://github.com/vinicioslc/adb-interface-vscode/issues/52) from vinicioslc/feat/eslint-format [[3f0c94c](https://github.com/vinicioslc/adb-interface-vscode/commit/3f0c94c7b5ec4e28e8e5652d1ddee85737c10f37)]
+-  feat: add .eslintrc and rules to format code correctly [[fe54cd1](https://github.com/vinicioslc/adb-interface-vscode/commit/fe54cd1244d496d6579a553b8af0a054e9498eac)]
+-  refactor(typescript): remove requirement of any explicit return, bump typescript formatter package [[5b3b258](https://github.com/vinicioslc/adb-interface-vscode/commit/5b3b2586841916fb6f55cf38c27f095a358a94fa)]
+-  Merge pull request [#51](https://github.com/vinicioslc/adb-interface-vscode/issues/51) from vinicioslc/dependabot/npm_and_yarn/thenify-3.3.1 [[b9de8b5](https://github.com/vinicioslc/adb-interface-vscode/commit/b9de8b599b311534a810853945a4ae5a7d7b2482)]
+-  build(deps): bump thenify from 3.3.0 to 3.3.1 [[1810568](https://github.com/vinicioslc/adb-interface-vscode/commit/181056857d659fe8485b0760133955a465471c6a)]
+-  Update README.md [[efcda0b](https://github.com/vinicioslc/adb-interface-vscode/commit/efcda0bd3b2b9f9b8eb2ed1749557512efbf270a)]
+-  Update README.md [[8ddb714](https://github.com/vinicioslc/adb-interface-vscode/commit/8ddb71401c5c76a8bcf1b4f7573c7d332dd6ea19)]
+-  Merge pull request [#50](https://github.com/vinicioslc/adb-interface-vscode/issues/50) from vinicioslc/dependabot/npm_and_yarn/minimist-1.2.6 [[ef6e86f](https://github.com/vinicioslc/adb-interface-vscode/commit/ef6e86fbd099229b6f2829f68ec80028d396a85b)]
+-  build(deps-dev): bump minimist from 1.2.3 to 1.2.6 [[cf4d44a](https://github.com/vinicioslc/adb-interface-vscode/commit/cf4d44a0cb2f3e95958e831f9a5e5cddb8de8802)]
+-  Merge pull request [#48](https://github.com/vinicioslc/adb-interface-vscode/issues/48) from vinicioslc/dependabot/npm_and_yarn/trim-off-newlines-1.0.3 [[6cbd168](https://github.com/vinicioslc/adb-interface-vscode/commit/6cbd1686e512eb7868f476e3143ce4c6b221e18d)]
+-  Merge pull request [#49](https://github.com/vinicioslc/adb-interface-vscode/issues/49) from vinicioslc/dependabot/npm_and_yarn/ini-1.3.8 [[8ab7e44](https://github.com/vinicioslc/adb-interface-vscode/commit/8ab7e446e865ebc1517d82f6da739f6d688ac8b2)]
+-  Merge pull request [#47](https://github.com/vinicioslc/adb-interface-vscode/issues/47) from vinicioslc/dependabot/npm_and_yarn/tar-4.4.19 [[a30d8db](https://github.com/vinicioslc/adb-interface-vscode/commit/a30d8dbaa5a89b9f61f8be2128a7e798fd39e678)]
+-  build(deps): bump ini from 1.3.5 to 1.3.8 [[747c12e](https://github.com/vinicioslc/adb-interface-vscode/commit/747c12e3adcca861ffcb6826ea437ef7c3c529bb)]
+-  build(deps): bump tar from 4.4.13 to 4.4.19 [[e5cdecf](https://github.com/vinicioslc/adb-interface-vscode/commit/e5cdecf7be5756cae405b20309c51d6437d61a25)]
+-  build(deps): bump trim-off-newlines from 1.0.1 to 1.0.3 [[1c69a46](https://github.com/vinicioslc/adb-interface-vscode/commit/1c69a4662468622d404e31339ff054c0118807da)]
+-  Merge pull request [#46](https://github.com/vinicioslc/adb-interface-vscode/issues/46) from vinicioslc/dependabot/npm_and_yarn/ajv-6.12.6 [[5ba5772](https://github.com/vinicioslc/adb-interface-vscode/commit/5ba5772937a69a44a43dd7e2c5c373ff8323c43c)]
+-  build(deps): bump ajv from 6.10.2 to 6.12.6 [[c1c9641](https://github.com/vinicioslc/adb-interface-vscode/commit/c1c96412ddcaea8fde421074bb8e42f1db028c46)]
+-  fix: hotfix for &#x27;undefined&#x27; error message on undefined length checks [[331d7a3](https://github.com/vinicioslc/adb-interface-vscode/commit/331d7a3da4bedefad8d1172bc6ec3f8243e56ac8)]
+-  Merge pull request [#43](https://github.com/vinicioslc/adb-interface-vscode/issues/43) from vinicioslc/fix/dependabot-removed [[d99a8de](https://github.com/vinicioslc/adb-interface-vscode/commit/d99a8de83cc7967910e3b14b07bc45ad0d980290)]
+-  ci: removed automerge [[b07f56c](https://github.com/vinicioslc/adb-interface-vscode/commit/b07f56c3d70a3d94018f6364c91f7c873e87c7fc)]
+-  Merge pull request [#42](https://github.com/vinicioslc/adb-interface-vscode/issues/42) from vinicioslc/fix/dependabot-removed [[82dda36](https://github.com/vinicioslc/adb-interface-vscode/commit/82dda361165b62c5456cdb4ee617ef07a6de6f86)]
+-  docs: removed unecessary comments [[e3bc9dd](https://github.com/vinicioslc/adb-interface-vscode/commit/e3bc9ddbbd86f1754ada1823e0c30b1daa46932e)]
+-  ci: removed badges for test [[65055a3](https://github.com/vinicioslc/adb-interface-vscode/commit/65055a3dcb3b674f9da682a146d18404a8bde6e5)]
+-  Merge pull request [#41](https://github.com/vinicioslc/adb-interface-vscode/issues/41) from vinicioslc/test/ci-automerge-test [[7e1e26a](https://github.com/vinicioslc/adb-interface-vscode/commit/7e1e26af23558990299f0d94eaaf20bc8e63f8fc)]
+-  ci: adds github token [[245ea7f](https://github.com/vinicioslc/adb-interface-vscode/commit/245ea7fb0ecdfdda1cfe37435f52db35bb35fd1c)]
+-  ci: adds github token [[e8ed210](https://github.com/vinicioslc/adb-interface-vscode/commit/e8ed210d4f3122f1f97ade3e85278c31e835f21d)]
+-  ci: changed automerge plugin [[7bf7391](https://github.com/vinicioslc/adb-interface-vscode/commit/7bf7391d5bc6a7873df76eb430a58b789916fcb4)]
+-  ci: alterado estrategia de automerge [[876764c](https://github.com/vinicioslc/adb-interface-vscode/commit/876764cd9106874a66ac90904484cff3d79ed341)]
+-  Merge pull request [#40](https://github.com/vinicioslc/adb-interface-vscode/issues/40) from vinicioslc/dependabot/npm_and_yarn/tmpl-1.0.5 [[9dc45a4](https://github.com/vinicioslc/adb-interface-vscode/commit/9dc45a44efea2a076bae3391c650fdb9c4d46d99)]
+-  Create codeql-analysis.yml [[480fa1f](https://github.com/vinicioslc/adb-interface-vscode/commit/480fa1ff740d41300c4bae660bb80f3d7ca6dde3)]
+-  ci: add automerge dependabot updates [[6c6e02d](https://github.com/vinicioslc/adb-interface-vscode/commit/6c6e02d132addb429c1568c1f058af8aed180d37)]
+-  ci: fixes automerge version [[e5cf361](https://github.com/vinicioslc/adb-interface-vscode/commit/e5cf361f7c3a30fd3b86663bb2f00ae331eb7ffe)]
+-  fix: add manualy dispatch actions [[df155e9](https://github.com/vinicioslc/adb-interface-vscode/commit/df155e989ec1bb22a5f13de7b4219e416a68b5ab)]
+-  Update automatic-merge.yml [[3cb0af6](https://github.com/vinicioslc/adb-interface-vscode/commit/3cb0af6aeb0bbc11ff8f4d2e78f99275fef9fc3b)]
+-  fix: add automerge feature for commits [[07914f0](https://github.com/vinicioslc/adb-interface-vscode/commit/07914f07c092e2abc488acd8b0a5dd40c155b29c)]
+-  build(deps): bump tmpl from 1.0.4 to 1.0.5 [[39db346](https://github.com/vinicioslc/adb-interface-vscode/commit/39db346970e67938619199de3c5bcdd0fc8b74c3)]
+-  Merge pull request [#38](https://github.com/vinicioslc/adb-interface-vscode/issues/38) from vinicioslc/dependabot/npm_and_yarn/path-parse-1.0.7 [[32a7689](https://github.com/vinicioslc/adb-interface-vscode/commit/32a76898e575116fcb59d541cbfbc8d95c3c720d)]
+-  fix: remove blank assignment [[09aa801](https://github.com/vinicioslc/adb-interface-vscode/commit/09aa801590f3ad34e7807db5050f1fbce908a39e)]
+-  build(deps): bump path-parse from 1.0.6 to 1.0.7 [[86d3624](https://github.com/vinicioslc/adb-interface-vscode/commit/86d36248bb322f36c9a72b3f599a1c0177a40368)]
+-  build(deps): bump trim-newlines from 3.0.0 to 3.0.1 [[d43fd27](https://github.com/vinicioslc/adb-interface-vscode/commit/d43fd273f08d732f0985f68afc65a0785b863d95)]
+-  build(deps): bump hosted-git-info from 2.8.5 to 2.8.9 [[4f330de](https://github.com/vinicioslc/adb-interface-vscode/commit/4f330defabeb2f883bdc080af7110b318299eab7)]
+-  build(deps): bump ws from 5.2.2 to 5.2.3 [[f323c26](https://github.com/vinicioslc/adb-interface-vscode/commit/f323c26958c0e22d4ac75aed0e28a1fa9c045d32)]
+-  docs: bump version [[5fda5c1](https://github.com/vinicioslc/adb-interface-vscode/commit/5fda5c1ba5b35fcaf023af7978f4ef5d859b4bb4)]
+-  fix: fix memento class errors due contract change [[c93705b](https://github.com/vinicioslc/adb-interface-vscode/commit/c93705b100c248620b36f55c8f21501623491b2b)]
+-  fix: bump vscode version [[6410cac](https://github.com/vinicioslc/adb-interface-vscode/commit/6410caca36dfe56a2b10dab1ed8aa313948a86c1)]
+-  Merge pull request [#34](https://github.com/vinicioslc/adb-interface-vscode/issues/34) from vinicioslc/dependabot/npm_and_yarn/lodash-4.17.21 [[eb698b6](https://github.com/vinicioslc/adb-interface-vscode/commit/eb698b6490cbe44611c94444fdd1c8656a7dcae5)]
+-  Merge pull request [#36](https://github.com/vinicioslc/adb-interface-vscode/issues/36) from vinicioslc/dependabot/npm_and_yarn/trim-newlines-3.0.1 [[11ce94f](https://github.com/vinicioslc/adb-interface-vscode/commit/11ce94f9a539073bfb6ee7deca7a369da0a524e9)]
+-  Merge pull request [#35](https://github.com/vinicioslc/adb-interface-vscode/issues/35) from vinicioslc/dependabot/npm_and_yarn/hosted-git-info-2.8.9 [[0c9384d](https://github.com/vinicioslc/adb-interface-vscode/commit/0c9384d7a65a3229f40e0ba02abb4071caa4f6ee)]
+-  Merge pull request [#37](https://github.com/vinicioslc/adb-interface-vscode/issues/37) from vinicioslc/dependabot/npm_and_yarn/ws-5.2.3 [[d118e2c](https://github.com/vinicioslc/adb-interface-vscode/commit/d118e2c47f0b6b46d566d8737fc80cd1a2569293)]
+-  Merge pull request [#31](https://github.com/vinicioslc/adb-interface-vscode/issues/31) from vinicioslc/dependabot/npm_and_yarn/y18n-4.0.1 [[5233f5a](https://github.com/vinicioslc/adb-interface-vscode/commit/5233f5a3822585c6062c45385554ca6554e40a7e)]
+-  Merge branch &#x27;dependabot/npm_and_yarn/trim-newlines-3.0.1&#x27; of https://github.com/vinicioslc/adb-wifi-code into production [[eecdf89](https://github.com/vinicioslc/adb-interface-vscode/commit/eecdf89bd20ba44daac11265b713e05ab5dcf8d9)]
+-  Merge branch &#x27;production&#x27; of https://github.com/vinicioslc/adb-wifi-code into production [[5948df6](https://github.com/vinicioslc/adb-interface-vscode/commit/5948df68e79f87719b8a911104c3e55d857688ae)]
+-  fix: remove deprecated package [[4f9d0a7](https://github.com/vinicioslc/adb-interface-vscode/commit/4f9d0a7b3c43ee597108527bb8c994d2e2a28f3e)]
+-  Update README.md [[1b753cc](https://github.com/vinicioslc/adb-interface-vscode/commit/1b753ccb6b7135364b92ad220e6d647f43ce21f4)]
+-  build(deps): bump trim-newlines from 3.0.0 to 3.0.1 [[8b30745](https://github.com/vinicioslc/adb-interface-vscode/commit/8b30745281570e4daf4b7b094a1192a414fc3481)]
+-  build(deps): bump lodash from 4.17.19 to 4.17.21 [[6d346e6](https://github.com/vinicioslc/adb-interface-vscode/commit/6d346e68fe560f90ec39f68da6bc6cbe5ecd237c)]
+-  Create stale.yml [[ae8d064](https://github.com/vinicioslc/adb-interface-vscode/commit/ae8d0649d3afe8b1fbe136ad2faa1926f001d134)]
+-  build(deps): bump y18n from 4.0.0 to 4.0.1 [[7138bde](https://github.com/vinicioslc/adb-interface-vscode/commit/7138bde0b07da1bb30c72f459d204abe9cd9b7b4)]
+-  fix: add markdown badges for sonar cloud [[31938a9](https://github.com/vinicioslc/adb-interface-vscode/commit/31938a90bf3a5a4bc79d627c4b25b25bec50f7e9)]
+-  fix: fixed tests [[17514a3](https://github.com/vinicioslc/adb-interface-vscode/commit/17514a38f127f636d61b38114182844dafa647e5)]
+-  ci: fix get tag name version in build pipeline [[f4e1601](https://github.com/vinicioslc/adb-interface-vscode/commit/f4e1601dbae8a5faf3e0305da2582657f6967330)]
+-  feat: add port selection during actions that closes issue [#30](https://github.com/vinicioslc/adb-interface-vscode/issues/30) [[22039a6](https://github.com/vinicioslc/adb-interface-vscode/commit/22039a6310e169f71005841f1f0ef1ae993737b0)]
+-  refactor: add commitlint to git hooks [[d5c3516](https://github.com/vinicioslc/adb-interface-vscode/commit/d5c3516cfd765f0f6fe8ef96597b1e322212a3e8)]
+-  fix(ci-cd): production build version fix [[f5d7eb4](https://github.com/vinicioslc/adb-interface-vscode/commit/f5d7eb44c971c19400dc4c0c7a0d03cf4da6c030)]
+-  Update README.md [[f28e9cf](https://github.com/vinicioslc/adb-interface-vscode/commit/f28e9cf05848632a7c3800a01fe53a2b471be1a5)]
+-  Merge pull request [#26](https://github.com/vinicioslc/adb-interface-vscode/issues/26) from moozzyk/adb-location-doc [[147bcbe](https://github.com/vinicioslc/adb-interface-vscode/commit/147bcbe4eb1bedf7f82b7d524e3779e3f08ab192)]
+-  Update table of contents [[f6a3414](https://github.com/vinicioslc/adb-interface-vscode/commit/f6a34148e914241df813db7a935712beb06c38ed)]
+-  docs(changelog.md): add next release details [[a75dc2b](https://github.com/vinicioslc/adb-interface-vscode/commit/a75dc2b9a8c72d06d732ad8a92fda4551cb22e62)]
+-  Merge pull request [#25](https://github.com/vinicioslc/adb-interface-vscode/issues/25) from vinicioslc/vinicioslc/issue23 [[d025e6d](https://github.com/vinicioslc/adb-interface-vscode/commit/d025e6dec7785cf023d8c86eb2e14e650ae83b6f)]
+-  fix(path-manager): hotfix in class ADBPathManager name wrong [[4ca8d45](https://github.com/vinicioslc/adb-interface-vscode/commit/4ca8d4517d04f4d5fca0e6885dad849c8365e6d2)]
+-  fix(custom-path): fix persistence when custom adb location setted [[3a0220a](https://github.com/vinicioslc/adb-interface-vscode/commit/3a0220a6dcc8031e9691f3f924c02eba23cb6611)]
+-  Update README.md [[87b6c73](https://github.com/vinicioslc/adb-interface-vscode/commit/87b6c734b8b15067c5a588624dbf5b245f40cdf9)]
+-  Merge pull request [#22](https://github.com/vinicioslc/adb-interface-vscode/issues/22) from vinicioslc/vinicioslc/issue18 [[07ecd4c](https://github.com/vinicioslc/adb-interface-vscode/commit/07ecd4cf4daa2d8f4b2dba80e7a453f696ea77bf)]
+-  Update README.md [[b7f1f4f](https://github.com/vinicioslc/adb-interface-vscode/commit/b7f1f4f16de1ffc3b7c2a427b63d90bc20f40e9b)]
+-  docs(gif): add gif demostrating how to install apks on devices [[d70306a](https://github.com/vinicioslc/adb-interface-vscode/commit/d70306a1298f302192c4c0f3be00d5e9d792656d)]
+-  Merge pull request [#20](https://github.com/vinicioslc/adb-interface-vscode/issues/20) from vinicioslc/vinicioslc/issue17 [[192d389](https://github.com/vinicioslc/adb-interface-vscode/commit/192d389211f6be5a49ecbde4970e3e4748a7f95a)]
+-  ci(deploy): improve production deploy strategy with tags [[c45f009](https://github.com/vinicioslc/adb-interface-vscode/commit/c45f00943e7ca559642d451e70f0c54f53176f79)]
+-  Merge pull request [#19](https://github.com/vinicioslc/adb-interface-vscode/issues/19) from vinicioslc/vinicioslc/issue16 [[cdea206](https://github.com/vinicioslc/adb-interface-vscode/commit/cdea2069a2eae78b0a01d5ec31e0ee15ea4d770f)]
+-  test(apk-installer): add integration test for apk-installer [[18fbbda](https://github.com/vinicioslc/adb-interface-vscode/commit/18fbbdaf9661071a7a01a90fda5cb41672843800)]
+-  Merge pull request [#15](https://github.com/vinicioslc/adb-interface-vscode/issues/15) from vinicioslc/feat/adb-apk-installer [[64d9602](https://github.com/vinicioslc/adb-interface-vscode/commit/64d96024b2d2a9b5f6642fd537c9eba35f01dc1a)]
+-  docs(apk-install): add documentation about APK install feature, and bumped version also. [[6d157f7](https://github.com/vinicioslc/adb-interface-vscode/commit/6d157f7eb43a22a3768cf7d0019a2259f4d6632a)]
+-  docs(CONTRIBUTING.md): change some details from how to contribute and commit [[9c368f5](https://github.com/vinicioslc/adb-interface-vscode/commit/9c368f5511085ae7e3d9e3fd58ee9fae8181fcfc)]
+-  feat(adb-install): add new pick apk functionality working. [[e29b90f](https://github.com/vinicioslc/adb-interface-vscode/commit/e29b90f2eeaea76b75ab90cd667e81875c801b7e)]
+-  docs(contributing): add contributing.md file for new contributors [[f7ab217](https://github.com/vinicioslc/adb-interface-vscode/commit/f7ab217746a94dc131ec5d860364efba659df0d9)]
+-  fix(build): bump yargs-parser version because vulnerabilities [[fba941d](https://github.com/vinicioslc/adb-interface-vscode/commit/fba941d862e69380d43c0f81392ebb7ea18c94c3)]
+-  ci(tests): now jest tests will be runned in pullrequests for production and deleop. [[609e8a8](https://github.com/vinicioslc/adb-interface-vscode/commit/609e8a8be5918923632cad763f3086a7a598a3e3)]
+-  ci(build): every deploy tag, must starts with deploy-vX.X.X to trigger build [[30a59c7](https://github.com/vinicioslc/adb-interface-vscode/commit/30a59c77087ad8bce04430039cba26780e6ba543)]
+-  ci(scripts): change ci/cd scripts names and remove master from pipeline. [[0255266](https://github.com/vinicioslc/adb-interface-vscode/commit/0255266b91cac4b3b705005afe3ada175abcf769)]
 
--   ADD - Adds port selection during connection.
 
-## 0.20.6
+<a name="0.19.3"></a>
+## 0.19.3 (2020-08-29)
 
--   FIX - Save ADB custom path when set it on ADBPathManager.
+### Miscellaneous
 
--   DOC - Added Info about strategy used by ADBResolver
+-  build(production): bump the version to be able deploy in store [[6679186](https://github.com/vinicioslc/adb-interface-vscode/commit/6679186b280a76b445a27c3714bb7871c7cc534e)]
+-  (readme): changed donation link and readme text layout. [[97376a4](https://github.com/vinicioslc/adb-interface-vscode/commit/97376a41bc48f28b3a255cb0ac7eab0a48b31c82)]
 
--   DOC - Added GIFs section in documentation demostrating how install apk on device
 
-## 0.20.5
+<a name="0.19.2"></a>
+## 0.19.2 (2020-08-20)
 
--   FIX - Improved CI/CD for deploy in production, now only need change the version on tagname like prod-v0.20.5 this will build and send the version 0.20.5 to the Extensions.
+### Miscellaneous
 
-## 0.20.4
+-  fix(images): correct readme.md image links [[8735e3c](https://github.com/vinicioslc/adb-interface-vscode/commit/8735e3ca5044fdf00216b6552aed3ee1d4e6fb73)]
 
--   NEW - Tests for apk fi
-    le picker, including apk install use cases.
 
-## 0.20.3
+<a name="0.19.1"></a>
+## 0.19.1 (2020-08-20)
 
--   NEW - Feature that enable install apk on connected device (Only windows tested).
+### Miscellaneous
 
-## 0.19.3
+-  refactor(folders): refactor folder structure [[24bb563](https://github.com/vinicioslc/adb-interface-vscode/commit/24bb5631a2f462409e7c210c067391c5e113876b)]
+-  fix(typescript build strategy): change compile command from typescript compiler [[9df7f5c](https://github.com/vinicioslc/adb-interface-vscode/commit/9df7f5c33d4fbda3861fe97811025a560824d8e7)]
+-  test(hipothesis proven): proving hypothesis that imports will work. [[9a85901](https://github.com/vinicioslc/adb-interface-vscode/commit/9a859011185cfaef8169875da4f51895d590ce2e)]
+-  test(before-deploy): add tests before deploy [[e451f9f](https://github.com/vinicioslc/adb-interface-vscode/commit/e451f9f7c7e6243dd93a76c33ddf944c55528b86)]
+-  (tests): fix tests broken due path name resolving [[3c1fbbb](https://github.com/vinicioslc/adb-interface-vscode/commit/3c1fbbbf71a4ba2e66faddcfde35970350668aa6)]
+-  style(code): added whitespaces in package.json [[4eeac23](https://github.com/vinicioslc/adb-interface-vscode/commit/4eeac2301734c7005b3534974a0258dbffcce296)]
+-  fix(tests): fix broken tests [[05fb9be](https://github.com/vinicioslc/adb-interface-vscode/commit/05fb9be6844e8a24b5e19489df2c3b09cf7bbf5b)]
+-  ci(production-deploy): change the deploy strategy [[6141de0](https://github.com/vinicioslc/adb-interface-vscode/commit/6141de07399aa703a2fdea041c065cd30ef32d2b)]
+-  Merge remote-tracking branch &#x27;origin/production&#x27; into fix/ip-connection [[46d1b21](https://github.com/vinicioslc/adb-interface-vscode/commit/46d1b21cf02591c020634c70cdf2c6c67c1d3dde)]
+-  fix(ip-connection): remove the hability of find ip device name [[6d46e7b](https://github.com/vinicioslc/adb-interface-vscode/commit/6d46e7bd5cab01b698095f78ffdc5445b63cf3c2)]
+-  Refactor on folder organization. and some progress in code classification. [[81eb85b](https://github.com/vinicioslc/adb-interface-vscode/commit/81eb85be633e5ff493f0660fd189bda536c442ab)]
+-  Merge pull request [#12](https://github.com/vinicioslc/adb-interface-vscode/issues/12) from vinicioslc/master [[b09afe3](https://github.com/vinicioslc/adb-interface-vscode/commit/b09afe36981efd395bc336feebe66bc285a576a3)]
+-  Fixed Production version. [[ca3207c](https://github.com/vinicioslc/adb-interface-vscode/commit/ca3207cd5c1c6ac5647b5c4a7b77aabd09b93cbc)]
+-  Merge branch &#x27;feature/adb-folder-picker&#x27; [[ce8fb74](https://github.com/vinicioslc/adb-interface-vscode/commit/ce8fb74d94bae731c6a7b08444a7b907718ea825)]
+-  New Release Candidate. [[753f168](https://github.com/vinicioslc/adb-interface-vscode/commit/753f1687dae594215a097c8f0652ef95a2c5834a)]
+-  Added adb path controller/manager for custom adb path. [[aee14e9](https://github.com/vinicioslc/adb-interface-vscode/commit/aee14e95700b7c6d3d74aff7da9255d25d442506)]
+-  Improved actions and readme. [[7ae421c](https://github.com/vinicioslc/adb-interface-vscode/commit/7ae421c49426a987083dffc34c409ff6e4d22cee)]
+-  Atualizado README.md [[a59b4e8](https://github.com/vinicioslc/adb-interface-vscode/commit/a59b4e8f03ea918c2c08b3ea5a776b897fe72aa6)]
+-  Refactor and mocked lan helpers class to enable testing. Implemented custom adb path check when search for ADB tool. [[70573a4](https://github.com/vinicioslc/adb-interface-vscode/commit/70573a44946200967e60f657d28fb022e1dae322)]
+-  Changed production version strategy. [[e5a56e4](https://github.com/vinicioslc/adb-interface-vscode/commit/e5a56e4d38bdf0cc7e356b1c696c2d88c9c230a0)]
+-  Bump lodash from 4.17.15 to 4.17.19 [[75719b1](https://github.com/vinicioslc/adb-interface-vscode/commit/75719b183ad723e08b2a50a795d4380cc1ed61f6)]
+-  Merge pull request [#10](https://github.com/vinicioslc/adb-interface-vscode/issues/10) from vinicioslc/dependabot/npm_and_yarn/lodash-4.17.19 [[3326686](https://github.com/vinicioslc/adb-interface-vscode/commit/3326686762e6bbddf70fcd9beaf86c68a8e9881b)]
+-  Hotfix Readme.md [[1ae1c27](https://github.com/vinicioslc/adb-interface-vscode/commit/1ae1c278c56543ccc32885a2dff5e7b8c94a2e79)]
+-  Added buy me a coffee button. [[106f164](https://github.com/vinicioslc/adb-interface-vscode/commit/106f164675bf08108f75a596b144231da3bc4908)]
+-  Hotfix deploy script. [[da2e0d7](https://github.com/vinicioslc/adb-interface-vscode/commit/da2e0d76fdee182345718aa387f202063ffb8a16)]
+-  Merge branch &#x27;release/refactor-adb-resolver&#x27; [[ef7d473](https://github.com/vinicioslc/adb-interface-vscode/commit/ef7d4731a7684fe19a2cd25d466597989f84792e)]
+-  Released commits with new folder structure. [[5e3ea9d](https://github.com/vinicioslc/adb-interface-vscode/commit/5e3ea9d041012dc29bacabf8877b9cc30835ed71)]
+-  Renamed ADBController for a coesive class [[3cab08b](https://github.com/vinicioslc/adb-interface-vscode/commit/3cab08bce6169c0fe5d96eda8faaff846caeaab2)]
+-  Improved responsability from controller. [[d1942d9](https://github.com/vinicioslc/adb-interface-vscode/commit/d1942d923bbeb0e9a2dfa342dc94895070371640)]
+-  Moved test files for correct location. [[53623cb](https://github.com/vinicioslc/adb-interface-vscode/commit/53623cb84d210a984eb7a08591ee71c1d89b0ff2)]
+-  Refactor in entire plugin concept. [[d6d8b25](https://github.com/vinicioslc/adb-interface-vscode/commit/d6d8b2595000a4a655dec8325a1319a5749af1bc)]
+-  Revert engine change erroneusly. [[14b32f0](https://github.com/vinicioslc/adb-interface-vscode/commit/14b32f0f14045ad247aa425ef00f3cb6dc67f539)]
+-  Renamed test case. [[05e2a14](https://github.com/vinicioslc/adb-interface-vscode/commit/05e2a14582ee7afae853befd357af218f1c1a099)]
+-  v1.26.0 Added tests passing correctly. [[5b3d960](https://github.com/vinicioslc/adb-interface-vscode/commit/5b3d960548aaf7619869171e74019e0ad2b7ea22)]
+-  New funcionality to console.mock [[4c58dc8](https://github.com/vinicioslc/adb-interface-vscode/commit/4c58dc8201a2ee8c25f7422f007f9b91a32c745c)]
+-  Organization Readme. [[c3081cb](https://github.com/vinicioslc/adb-interface-vscode/commit/c3081cbe786675d37f7e5cb8dd44ca2808044654)]
+-  Improved Readme File. [[a89c65d](https://github.com/vinicioslc/adb-interface-vscode/commit/a89c65d47b01e51d1d6488724a08c384d11f1b99)]
+-  Update README.md [[dd06e56](https://github.com/vinicioslc/adb-interface-vscode/commit/dd06e56babb910eff1b2d6c24b86916551c19556)]
+-  Starting implement [[8e6f676](https://github.com/vinicioslc/adb-interface-vscode/commit/8e6f6766bec8696da570e6b7a01e43eba2fdb376)]
+-  Merge branch &#x27;master&#x27; into refactor-classes-organization [[94751d5](https://github.com/vinicioslc/adb-interface-vscode/commit/94751d522c6b59815a63e0bbb28b8495f43c7c65)]
+-  Merge branch &#x27;refactor-classes-organization&#x27; Fixed [#7](https://github.com/vinicioslc/adb-interface-vscode/issues/7) Added changelog.md Released version 0.17.2 [[917a3cf](https://github.com/vinicioslc/adb-interface-vscode/commit/917a3cf444fda22345b7d6faed3eb91965000e94)]
+-  Hotfix. [[80c1228](https://github.com/vinicioslc/adb-interface-vscode/commit/80c12281e4d08db6b7b5b4f4c4b8bdeb578902c7)]
+-  Changed console-interface folder and moved from adb-manager -&gt; adb-wrapper folder. [[887dd57](https://github.com/vinicioslc/adb-interface-vscode/commit/887dd57518f995468a0d19eb0654c60b39a03d8c)]
+-  Added deploy envs correctly. [[51cd3e9](https://github.com/vinicioslc/adb-interface-vscode/commit/51cd3e9b0201386c5d378d07a6424b87124878da)]
+-  Added enviroments to deploy script. [[4b93c07](https://github.com/vinicioslc/adb-interface-vscode/commit/4b93c07b3c0a40cc4aa7d59e937121dec92180f4)]
+-  Added npx for common comands. [[ee536d0](https://github.com/vinicioslc/adb-interface-vscode/commit/ee536d0c11f5a2084a7aae128de9e360e29aafdd)]
+-  Removed tests from deploy branch. [[c15603d](https://github.com/vinicioslc/adb-interface-vscode/commit/c15603dfc2040e2cd86bf42a9831836f43060feb)]
+-  Merge pull request [#5](https://github.com/vinicioslc/adb-interface-vscode/issues/5) from vinicioslc/release/automated-publish [[86b6e09](https://github.com/vinicioslc/adb-interface-vscode/commit/86b6e0946f470133bde43a19c87455e9b7810f65)]
+-  Test publish [[40c270e](https://github.com/vinicioslc/adb-interface-vscode/commit/40c270e0ece78f86a8161fac39002fc0405a47ef)]
+-  Deploy actions added. [[67f90ff](https://github.com/vinicioslc/adb-interface-vscode/commit/67f90ffbf93967d544173a6694dc382595ba39c6)]
+-  Acorn installed. [[c137141](https://github.com/vinicioslc/adb-interface-vscode/commit/c137141b9e9d9efeacaec6d048f3d8302726618f)]
+-  Fix vulnerability. [[dabd4cc](https://github.com/vinicioslc/adb-interface-vscode/commit/dabd4cc76ceda3e2de6da742cf7b3ffd7cdd2c69)]
+-  Changed vscode ignore [[dcea1d6](https://github.com/vinicioslc/adb-interface-vscode/commit/dcea1d61d4c56a1634ed6ac13ba0010f9074e79b)]
+-  Changed vscode ignore. [[2cbc81b](https://github.com/vinicioslc/adb-interface-vscode/commit/2cbc81bcb66b8cdd372d60536dc179afe282d688)]
+-  Fix version number [[7370f31](https://github.com/vinicioslc/adb-interface-vscode/commit/7370f31f24a0a9d2f787bb0a6a92ad99db92839a)]
+-  0.16.0 [[b6a0a72](https://github.com/vinicioslc/adb-interface-vscode/commit/b6a0a72c792d43945028bf0071d0841d829304f7)]
+-  Revert version. [[ebcfc3e](https://github.com/vinicioslc/adb-interface-vscode/commit/ebcfc3ea378c524b19b79f6e97d35102961bd79b)]
+-  Removed Crashing Tests. [[3aa7f35](https://github.com/vinicioslc/adb-interface-vscode/commit/3aa7f353eca97e69d113f6f3f41fd856fa90e2e2)]
+-  0.16.0 [[de57cce](https://github.com/vinicioslc/adb-interface-vscode/commit/de57cce8e4b23ddc9b1593c739c1665979231e41)]
+-  Added new messaging strategy during connection FIXED [#4](https://github.com/vinicioslc/adb-interface-vscode/issues/4) [[608db22](https://github.com/vinicioslc/adb-interface-vscode/commit/608db22aac6ad7af66c2e977a3d970867e129b19)]
+-  Bumped minimist due vulnerability advisor. [[9e563cd](https://github.com/vinicioslc/adb-interface-vscode/commit/9e563cda125cec283c541d6aa5fb6967ec35fb67)]
+-  Merge pull request [#3](https://github.com/vinicioslc/adb-interface-vscode/issues/3) from vinicioslc/dependabot/npm_and_yarn/acorn-5.7.4 [[af658ef](https://github.com/vinicioslc/adb-interface-vscode/commit/af658ef35fc985f9c083ab0593957dbe45511eb9)]
+-  0.15.0 [[6c76ff4](https://github.com/vinicioslc/adb-interface-vscode/commit/6c76ff46146ea0ee3675dbdd439624e3686b6e17)]
+-  Improved Message During Connection. [[a4e03cf](https://github.com/vinicioslc/adb-interface-vscode/commit/a4e03cf2dc40dbc7a5d6293b12b2d5459167cbc1)]
+-  Bump acorn from 5.7.3 to 5.7.4 [[006419c](https://github.com/vinicioslc/adb-interface-vscode/commit/006419ccb13c2fa6b50fcb8d5336d5c4a6476eaf)]
+-  0.14.0 [[73196bb](https://github.com/vinicioslc/adb-interface-vscode/commit/73196bb61d571faf06b733a5e7d10d095fef5956)]
+-  Hotfix messages. [[4af8b68](https://github.com/vinicioslc/adb-interface-vscode/commit/4af8b681c861faac4e322fc6f4f6447b1b7f2a94)]
+-  Updated Badges. [[4b63a30](https://github.com/vinicioslc/adb-interface-vscode/commit/4b63a30954fa0815a21dea18712c22c10cad3430)]
+-  Improved Readme Syntax [[3b4be61](https://github.com/vinicioslc/adb-interface-vscode/commit/3b4be6197af9459906d4549f794b448612fb6539)]
+-  Added code quality [[4f26e04](https://github.com/vinicioslc/adb-interface-vscode/commit/4f26e0460aab22d64f1350e053f78eb1809ce563)]
+-  Removed unused code. [[3a0541d](https://github.com/vinicioslc/adb-interface-vscode/commit/3a0541d81e137a4f128c29b024b8995aa7443697)]
+-  - Improved plugin commands location and fixes in commands registry. - Improved Readme [[7209b8b](https://github.com/vinicioslc/adb-interface-vscode/commit/7209b8b42d696180ee22b544c88e1c4a3af4eed5)]
+-  0.13.0 [[0d13edd](https://github.com/vinicioslc/adb-interface-vscode/commit/0d13eddf393a43dee6f504a9cbfb48f6322bf973)]
+-  Updated readme.md [[f3cf435](https://github.com/vinicioslc/adb-interface-vscode/commit/f3cf435007bb4c1289f613c5ee1458025662cf10)]
+-  0.12.0 [[a93019b](https://github.com/vinicioslc/adb-interface-vscode/commit/a93019bc8290bca926932894e6403ce4e553f0a0)]
+-  updated publish command [[6f01e87](https://github.com/vinicioslc/adb-interface-vscode/commit/6f01e87fe9950003ff562d286fccabae0834dfaf)]
+-  0.11.0 [[dc9a9ba](https://github.com/vinicioslc/adb-interface-vscode/commit/dc9a9ba0d1536344e9c5106f1729e0d6fe176223)]
+-  Updated badge generator to png support. [[bcdeea0](https://github.com/vinicioslc/adb-interface-vscode/commit/bcdeea040e899611c4e385ab55ff7b5e391cb96f)]
+-  0.10.0 [[d8c4af0](https://github.com/vinicioslc/adb-interface-vscode/commit/d8c4af0204242a341bb718e020013221ee6b871c)]
+-  Updated readme [[5fccb82](https://github.com/vinicioslc/adb-interface-vscode/commit/5fccb82940e39a5a1c42cde526bb1c1d54b6f1bd)]
+-  0.9.0 [[69c345c](https://github.com/vinicioslc/adb-interface-vscode/commit/69c345c6aed423f8646ac2972282fb40bcde27e4)]
+-  Changed scripts run order [[e25c251](https://github.com/vinicioslc/adb-interface-vscode/commit/e25c2517865ed1ba3a96fb6336265c35ae3d5481)]
+-  Merge branch &#x27;@fix-found-lan-devices&#x27; of https://github.com/vinicioslc/adb-wifi-code [[5bce4b8](https://github.com/vinicioslc/adb-interface-vscode/commit/5bce4b8777c1896b504183202aa10fc32e20d495)]
+-  Improved commands registry. [[1ad6584](https://github.com/vinicioslc/adb-interface-vscode/commit/1ad65841dc62940f53fe5ae1c76957340cc3385a)]
+-  Hotfix package.json [[86011de](https://github.com/vinicioslc/adb-interface-vscode/commit/86011deecab5cf241f7905dd85607c07ed90e8d4)]
+-  Added code coverage badges. [[ff9ffe6](https://github.com/vinicioslc/adb-interface-vscode/commit/ff9ffe6fe71820a888f20f7c6f0cefe92859ed09)]
+-  Improvements in error handling. [[b66f263](https://github.com/vinicioslc/adb-interface-vscode/commit/b66f263cb86ba3c036ec43208606a685e17ecaff)]
+-  Improvements in code quality [[3fcb3f8](https://github.com/vinicioslc/adb-interface-vscode/commit/3fcb3f86c08c2efc8307b9e51cf0065ca8b2d55b)]
+-  Changed from toLocaleString() to toString() [[2fc4255](https://github.com/vinicioslc/adb-interface-vscode/commit/2fc4255b87ec10a8ea1a4826410e710e5ae7d450)]
+-  0.8.3 [[b93c9e3](https://github.com/vinicioslc/adb-interface-vscode/commit/b93c9e3c2af758b826ae33cb1cf638e0dc1ef8e1)]
+-  Added readme.todo, add exceptions in adb commands. Renamed Functions and extracted more helpers. [[47a63d3](https://github.com/vinicioslc/adb-interface-vscode/commit/47a63d3a8dc357339f0a620d8f07ca9e0755e092)]
+-  More refactor and decoupled adb-helpers. [[f8a468f](https://github.com/vinicioslc/adb-interface-vscode/commit/f8a468f985e3b2895daa726460cdbee8dfde79a2)]
+-  0.8.2 [[ac3c49b](https://github.com/vinicioslc/adb-interface-vscode/commit/ac3c49bf1eeff035f6ab44e2c2949a3bed426e1b)]
+-  Renamed Extension. [[7b975ba](https://github.com/vinicioslc/adb-interface-vscode/commit/7b975ba9016c2074a739f20b4e77d1b5c375ecfc)]
+-  Added more tests and some refactor in codebase. [[b74b030](https://github.com/vinicioslc/adb-interface-vscode/commit/b74b03022cc7c4868ded3fbed8be05af82362368)]
+-  0.8.1 [[f62e640](https://github.com/vinicioslc/adb-interface-vscode/commit/f62e640a4810b2c05db08242a714d50536d7baac)]
+-  Hotfix [[c5f70b8](https://github.com/vinicioslc/adb-interface-vscode/commit/c5f70b8f27ba5fc0616eaafd676cf46ea811ebab)]
+-  0.8.0 [[e07290a](https://github.com/vinicioslc/adb-interface-vscode/commit/e07290abbda758efc540a863d6bb17018b8a0294)]
+-  Added much more tests. [[d89212f](https://github.com/vinicioslc/adb-interface-vscode/commit/d89212f7103f285bd29cfa5977c9975b32883332)]
+-  Added warning emoji. [[097f315](https://github.com/vinicioslc/adb-interface-vscode/commit/097f31529ee9bf6dccb9f585de1b5ecca4d9b806)]
+-  New Icon [[7ec8cc8](https://github.com/vinicioslc/adb-interface-vscode/commit/7ec8cc87214271d8565a26d5ecb8b1ee227256f7)]
+-  0.7.3 [[f57e876](https://github.com/vinicioslc/adb-interface-vscode/commit/f57e87611b6ba5542e56b0be65ce47cd5b2ad60c)]
+-  Fix icon extension. [[1552fe5](https://github.com/vinicioslc/adb-interface-vscode/commit/1552fe55d768e70129cbb0486a7ff6f9794f7ca5)]
+-  Fix build typescript version [[ecffe24](https://github.com/vinicioslc/adb-interface-vscode/commit/ecffe242e8967cad4d0d541196b6775048c576fb)]
+-  0.7.2 [[7ab6127](https://github.com/vinicioslc/adb-interface-vscode/commit/7ab6127c47c751345cee577a962db90c66040f67)]
+-  0.8.0 [[b0e5802](https://github.com/vinicioslc/adb-interface-vscode/commit/b0e5802bc8895bdfa326a1cfe4ae1b8da632eac2)]
+-  Merge branch &#x27;IanSC-master&#x27; [[6c21d5e](https://github.com/vinicioslc/adb-interface-vscode/commit/6c21d5e239cb2448d07481c68dc269a6eca810e7)]
+-  Merge branch &#x27;master&#x27; of https://github.com/IanSC/adb-interface-vscode into IanSC-master [[fd590f4](https://github.com/vinicioslc/adb-interface-vscode/commit/fd590f48028868f48eb338f51a1bb08647b977d2)]
+-  Improved readme disposition. [[cabdaf9](https://github.com/vinicioslc/adb-interface-vscode/commit/cabdaf9b79080aa342cbde23fb45c74c650cca2f)]
+-  Refactor markdown layout [[349ab40](https://github.com/vinicioslc/adb-interface-vscode/commit/349ab40725d5c2090cd3cb92f4cd09c0d39984ee)]
+-  Update README.md [[9d468d6](https://github.com/vinicioslc/adb-interface-vscode/commit/9d468d62ee18aadb4a952145fc6ea29c87b04804)]
+-  Improved layout readme.md [[cf54713](https://github.com/vinicioslc/adb-interface-vscode/commit/cf54713d9094a7492f6e92ae287ccc9a720988f6)]
+-  Added github badge. [[27790b9](https://github.com/vinicioslc/adb-interface-vscode/commit/27790b997e493edbf96d1932d83febacc71335c1)]
+-  Github Actions fixed - Removed travis.ci [[b0afcc0](https://github.com/vinicioslc/adb-interface-vscode/commit/b0afcc0b9361b023d3efd2ce0cdcfbb3a0fc5f9b)]
+-  Create blank.yml [[af093de](https://github.com/vinicioslc/adb-interface-vscode/commit/af093deafc7ae783402101566e1ddc2999b71c7e)]
+-  - Fix travis ci runing &quot;jest watchAll&quot;. [[3032cf0](https://github.com/vinicioslc/adb-interface-vscode/commit/3032cf0282b98f88e329fd8ac5ae6fc7be04d0c2)]
+-  Merge branch &#x27;@refactor_adb-actions&#x27; [[79a8abe](https://github.com/vinicioslc/adb-interface-vscode/commit/79a8abe2be94fb0a823f457928821ede251b2324)]
+-  Added Travis.ci [[77688a3](https://github.com/vinicioslc/adb-interface-vscode/commit/77688a3ee6457ff72d25a15e8658a5eb2927e50d)]
+-  Fixed icon warning. [[9060570](https://github.com/vinicioslc/adb-interface-vscode/commit/9060570865fb0812742c7f05108c3a229ced44a6)]
+-  Merge branch &#x27;master&#x27; of https://github.com/vinicioslc/adb-wifi-code into @refactor_adb-actions [[12d55dc](https://github.com/vinicioslc/adb-interface-vscode/commit/12d55dc1738ab6d611dcd6c625cbd2a91e46a7dc)]
+-  Refactoring progress - More refactor in class structure - Added more tests (Firebase) [[caf8fbb](https://github.com/vinicioslc/adb-interface-vscode/commit/caf8fbba0026ad26945be562f59ad47138631f3a)]
+-  - Refactor in class names. - Modularized command. [[94785c3](https://github.com/vinicioslc/adb-interface-vscode/commit/94785c390170c8915ffdeb6ba4b277d8370c740f)]
+-  Merge branch &#x27;@refactor_adb-actions&#x27; - Added jest as default test suite - Added some modularization on internal classes - more tests. .. [[6e0307c](https://github.com/vinicioslc/adb-interface-vscode/commit/6e0307c4c4541d8238a8808c0fdee778ba83f4cd)]
+-  - Modularization and refactors in adb-actions class - Added tests for listed devices [[fc3f131](https://github.com/vinicioslc/adb-interface-vscode/commit/fc3f131fea38b2c8d709bb73c7947055252ac3db)]
+-  Merge branch &#x27;@improvement_added-tests&#x27; into @refactor_adb-actions [[0bb05c1](https://github.com/vinicioslc/adb-interface-vscode/commit/0bb05c12bde31b8c91e358ffa245d7c2faffcb96)]
+-  Added Console Interface Implementation [[da573a9](https://github.com/vinicioslc/adb-interface-vscode/commit/da573a94399648365f8c9a2807c234d50096593e)]
+-  Removed logs [[67d7617](https://github.com/vinicioslc/adb-interface-vscode/commit/67d76173d8a5b48d54fe6f558e68a4245d09c93d)]
+-  Added Jest as default test suite. [[1a99579](https://github.com/vinicioslc/adb-interface-vscode/commit/1a995796e833aa086d1017a6868814ab922333fc)]
+-  Added tasks [[ca34250](https://github.com/vinicioslc/adb-interface-vscode/commit/ca34250d001e42f5fc5e29c0109fb7e6e4d98d3b)]
+-  Woking found lan devices to connect. [[bf371ae](https://github.com/vinicioslc/adb-interface-vscode/commit/bf371aebaf79bc6b90b360c4851067ac1a1838c5)]
+-  - Modularized global keys [[f9a7ec1](https://github.com/vinicioslc/adb-interface-vscode/commit/f9a7ec10210b9f8c351f2fed6914b8dc85ce1b1e)]
+-  Bumped some package versions. [[ad84d6e](https://github.com/vinicioslc/adb-interface-vscode/commit/ad84d6e4437bb4ee59a4719c1163330166b703af)]
+-  Added vscode ignore. Added npm pubm (publish minor command) [[4a7d530](https://github.com/vinicioslc/adb-interface-vscode/commit/4a7d530197704500701df468c820762718482a7a)]
+-  0.7.0 [[03825d6](https://github.com/vinicioslc/adb-interface-vscode/commit/03825d6eb9245d2c95807ac95b5db63466ba37a9)]
+-  Merge branch &#x27;@feature-kill-adb-server&#x27; - Added Kill ADB command - Made Some improvements in readme.md - Added one little quick start in readme.md [[424bec2](https://github.com/vinicioslc/adb-interface-vscode/commit/424bec2d2ddfd6ac859882fd50b777cc8239ea41)]
+-  Added text improvements. [[5979f67](https://github.com/vinicioslc/adb-interface-vscode/commit/5979f67992c954acdccd8562a9121ef25ed076b9)]
+-  Added activation event. [[29fb06d](https://github.com/vinicioslc/adb-interface-vscode/commit/29fb06d004a950cd6a0f91b4b492d074722f2cf7)]
+-  - Added ADB KIll Server Command [[5390592](https://github.com/vinicioslc/adb-interface-vscode/commit/5390592e004b23642703b09c8dd3cac7b2f53800)]
+-  - Improved naming of features and descriptions - Added one simply tutorial to connect to adb trough wifi. [[7ed87b3](https://github.com/vinicioslc/adb-interface-vscode/commit/7ed87b324740f6c58b4469474e463a2a94468f0d)]
+-  Changed ConnectToDeviceFromList() [[02b250b](https://github.com/vinicioslc/adb-interface-vscode/commit/02b250b6ee3a0abeb0c502e53cd1d09301713dc1)]
+-  0.6.0 [[1175ebe](https://github.com/vinicioslc/adb-interface-vscode/commit/1175ebe93e8cc0057a20ed04e8becb2c0b4f10b5)]
+-  New Commands [[22ba907](https://github.com/vinicioslc/adb-interface-vscode/commit/22ba9077c560465ad60db431151601da05e3eb58)]
+-  new firebase debug mode [[432976f](https://github.com/vinicioslc/adb-interface-vscode/commit/432976f65d1ddf2bf7b211a3941765a6d2883218)]
+-  Firebase Commands Added [[80447b7](https://github.com/vinicioslc/adb-interface-vscode/commit/80447b705c25aaecd5fbd9ddc9481291f1aba437)]
+-  Some refactor [[f3bfe43](https://github.com/vinicioslc/adb-interface-vscode/commit/f3bfe43e561783d72dcfb3d8d74f46bedb1d3d1a)]
+-  0.5.0 [[e33aa42](https://github.com/vinicioslc/adb-interface-vscode/commit/e33aa427762214c93f5e2344eecf44dc5b41d11e)]
+-  Enviroment Warning. [[a77bd49](https://github.com/vinicioslc/adb-interface-vscode/commit/a77bd497f0ae5563b312c963e8b47d35c2a19f13)]
+-  0.4.0 [[0e9970a](https://github.com/vinicioslc/adb-interface-vscode/commit/0e9970aba688ac015e322ad267527ffac8d520e1)]
+-  New firebase Methods and new description [[f4fd1d2](https://github.com/vinicioslc/adb-interface-vscode/commit/f4fd1d228626fb3c2b1ecd7b292d43b78ef4acd2)]
+-  Update README.md [[1022398](https://github.com/vinicioslc/adb-interface-vscode/commit/10223981e08bead7dbff56ccb75240fa5df85ba9)]
+-  Fix Vulnerability [[a493a66](https://github.com/vinicioslc/adb-interface-vscode/commit/a493a669268a76d6151e8fe87792b24f2ab06581)]
+-  version bump [[bf93aa1](https://github.com/vinicioslc/adb-interface-vscode/commit/bf93aa1f2c5e92fd6ba9c17b473d78250ac24264)]
+-  Readme update [[6d6e12c](https://github.com/vinicioslc/adb-interface-vscode/commit/6d6e12c5ddb78f9e02a8c1e39f648782550482b0)]
+-  git ignore file [[12437ec](https://github.com/vinicioslc/adb-interface-vscode/commit/12437ec753f8f5acb7421776621c13c6c9344c1c)]
+-  0.3.0 [[9686369](https://github.com/vinicioslc/adb-interface-vscode/commit/968636943126e9e5834eee4aa21c91bc26f6dd24)]
+-  New lan ip listing [[0d61978](https://github.com/vinicioslc/adb-interface-vscode/commit/0d61978dfbf810b6a85d6d5004b9cf24fa3337bd)]
+-  new code style [[6630381](https://github.com/vinicioslc/adb-interface-vscode/commit/66303810ff2b854457283cb7e393db3bb26aa72c)]
+-  0.2.1 [[d98ebf7](https://github.com/vinicioslc/adb-interface-vscode/commit/d98ebf7ec30857b9eab71624c1c413c7c69ffc1f)]
+-  New Version [[5c8a46b](https://github.com/vinicioslc/adb-interface-vscode/commit/5c8a46b88a7e0bd52c63b3ff8e0284ae4efd4a25)]
+-  nothing more [[f1dbbc9](https://github.com/vinicioslc/adb-interface-vscode/commit/f1dbbc9afaa2691fa87df85ab5fe361cb1f1bbc7)]
+-  0.2.0 [[23e8aeb](https://github.com/vinicioslc/adb-interface-vscode/commit/23e8aeb7d93a368af07e450a40b8a69afaecc298)]
+-  Removed out dir. [[b48ad0f](https://github.com/vinicioslc/adb-interface-vscode/commit/b48ad0f456db0d57d92c55ae43a43704dc39d055)]
+-  Added port to new adb requirements. [[e5a28f3](https://github.com/vinicioslc/adb-interface-vscode/commit/e5a28f33ca7c368b1957d9f0a5dcffbf1538da04)]
+-  0.1.3 [[4c6e9a7](https://github.com/vinicioslc/adb-interface-vscode/commit/4c6e9a718ce38d42de7aa4f9be271851e3a3c35b)]
+-  Text correction. [[fc33330](https://github.com/vinicioslc/adb-interface-vscode/commit/fc33330a4d2e96132cb50800a96943326007ddb3)]
+-  0.1.2 [[47b4080](https://github.com/vinicioslc/adb-interface-vscode/commit/47b408045e63035ee2c5bdb99ad900b1c0235f51)]
+-  0.1.1 [[e6322ec](https://github.com/vinicioslc/adb-interface-vscode/commit/e6322ecc2961c1d325b543128146b1b5c2eff566)]
+-  Added new graphics. [[f3c1872](https://github.com/vinicioslc/adb-interface-vscode/commit/f3c1872e547bc0ff978ab8d81c1657622392ddc6)]
+-  0.1.0 [[c14b0a4](https://github.com/vinicioslc/adb-interface-vscode/commit/c14b0a4faaef95770be0ae86fcb528778d1b9669)]
+-  Added new feature to connect from a list of devices. [[745e31d](https://github.com/vinicioslc/adb-interface-vscode/commit/745e31d6c3520b3e4e8afb4c3a37651478c2241f)]
+-  0.0.6 [[901f3c6](https://github.com/vinicioslc/adb-interface-vscode/commit/901f3c657b352a717d58242990da5c8c7c38e269)]
+-  Corrected name. [[c13bbca](https://github.com/vinicioslc/adb-interface-vscode/commit/c13bbca19539eef1fddf61168ca12ead6d369dba)]
+-  Description [[2d30dd7](https://github.com/vinicioslc/adb-interface-vscode/commit/2d30dd7a0243b1b75c3f8cd69571ec96d3a79da4)]
+-  Added alert [[b432c4d](https://github.com/vinicioslc/adb-interface-vscode/commit/b432c4d318148b2558aa38ab54200dcb9a8734b3)]
+-  Updated README.md [[6f89fa5](https://github.com/vinicioslc/adb-interface-vscode/commit/6f89fa55ffc55e23bd37cb919fbb8963a2a3c05d)]
+-  Some Corrections for publish [[1078c68](https://github.com/vinicioslc/adb-interface-vscode/commit/1078c68e626bbbc754a6fd715c7dddcd6281ae92)]
+-  Added disconnect functionality and code improvements. [[48e86b0](https://github.com/vinicioslc/adb-interface-vscode/commit/48e86b06b0528e3cea351d4710228abe63e72264)]
+-  Improved comunication interface with adb [[c0a821a](https://github.com/vinicioslc/adb-interface-vscode/commit/c0a821a3d3c56fc2a0581cb3d18ee365ade193cb)]
+-  Merge branch &#x27;master&#x27; of https://github.com/vinicioslc/adb-wifi-code [[a2ad74d](https://github.com/vinicioslc/adb-interface-vscode/commit/a2ad74d342151eb766ac320fadf5bcc5c71f8f88)]
+-  Added basic functionality. [[06c2037](https://github.com/vinicioslc/adb-interface-vscode/commit/06c2037f20a22b89feefb4d4951753febbff78e0)]
+-  Update README.md [[6eedb71](https://github.com/vinicioslc/adb-interface-vscode/commit/6eedb71c3c237687a236828f44b0575dca1b55ce)]
+-  Initial commit. [[32671aa](https://github.com/vinicioslc/adb-interface-vscode/commit/32671aa482cfa37a95c13e0491b05eea9058fc8c)]
+-  Update README.md [[5068904](https://github.com/vinicioslc/adb-interface-vscode/commit/5068904a41d6ed679a86c0ae66eb918055b68872)]
+-  Initial commit [[bb2bf9b](https://github.com/vinicioslc/adb-interface-vscode/commit/bb2bf9bb91b5b53d0634081e12446a0dc52d22b3)]
 
--   DOC - README links and layout (nothing important).
 
-## 0.19.2
-
--   FIX - Change broken image links from README.md to working image links, for VSCode extensions.
-
-## 0.19.1
-
--   FIX - Issue #13 when connect throws an error, showing error message.
-
-## 0.19.0
-
--   NEW - Bump version for new feature `Custom ADB path picker`
--   NEW - ADB Path Picker able to select custom adb executable path
--   IMPROVED - Tests with `net-helpers` mocking the class
--   IMPROVED - CHANGELOG.md layout
-
-## 0.18.3
-
--   IMPROVED - README.md layout
-
-## 0.18.2
-
--   IMPROVED - New buy meacoffee.com button on README.md
-
-## 0.18.1
-
--   NEW - Refactor at codebase with `plugin controllers` startegy.
--   NEW - Changed Folder structure.
-
-## 0.18.0
-
--   NEW - Test cases for `adb-resolver` use cases.
-
--   NEW - Improve how extension search `ADB` in enviroment adding `adb-resolver` strategy.
-
--   FIX - Enviroment variables is now accessed directly from path.
-
-## 0.17.2
-
--   FIX - for issue #7 removing necessity to close "Connecting to X" message
-
-## 0.17.1
-
--   NEW - fully ci/cd enviroment, now new commits in master will be released to production on extensions.
-
-## Past
-
--   OLD - Forbiden Changes
-    ...


### PR DESCRIPTION
Standarlize CHANGELOG.md changes to ensure new gitmoji standard